### PR TITLE
Make GitHub detect *.txt as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.txt linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect your `.txt` files as Forth.

Thanks!
